### PR TITLE
Fix deprecated $header-sizes warning

### DIFF
--- a/app/stylesheets/_foundation-settings.scss
+++ b/app/stylesheets/_foundation-settings.scss
@@ -155,22 +155,22 @@ $header-margin-bottom: 0.5rem;
 //     'h6': ('font-size': 16),
 //   ),
 // );
-$header-sizes: (
+$header-styles: (
   small: (
-    'h1': 24,
-    'h2': 20,
-    'h3': 19,
-    'h4': 18,
-    'h5': 17,
-    'h6': 16,
+    'h1': ('font-size': 24),
+    'h2': ('font-size': 20),
+    'h3': ('font-size': 19),
+    'h4': ('font-size': 18),
+    'h5': ('font-size': 17),
+    'h6': ('font-size': 16),
   ),
   medium: (
-    'h1': 26,
-    'h2': 24,
-    'h3': 20,
-    'h4': 18,
-    'h5': 17,
-    'h6': 16,
+    'h1': ('font-size': 26),
+    'h2': ('font-size': 24),
+    'h3': ('font-size': 20),
+    'h4': ('font-size': 18),
+    'h5': ('font-size': 17),
+    'h6': ('font-size': 16),
   ),
 );
 $header-text-rendering: optimizeLegibility;

--- a/public/index.html
+++ b/public/index.html
@@ -2149,7 +2149,7 @@
                   <div class="prop-row prop-group">
                     <div class="prop-name">
                       <div class="prop-title">200 OK</div>
-                      <div class="prop-ref"> </div>
+                      <div class="prop-ref"></div>
                       <!-- <span class="swagger-global"></span> <span class="json-schema-reference"><a href=""></a></span> -->
                     </div>
                     <div class="prop-value">
@@ -2641,8 +2641,7 @@
           <div id="definition-Order" class="definition panel" data-traverse-target="definition-Order">
             <h2 class="panel-title">
               <a name="/definitions/Order"></a>Order: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               
@@ -2718,8 +2717,7 @@
           <div id="definition-Category" class="definition panel" data-traverse-target="definition-Category">
             <h2 class="panel-title">
               <a name="/definitions/Category"></a>Category: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               
@@ -2759,8 +2757,7 @@
           <div id="definition-Customer" class="definition panel" data-traverse-target="definition-Customer">
             <h2 class="panel-title">
               <a name="/definitions/Customer"></a>Customer: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               
@@ -2851,8 +2848,7 @@
           <div id="definition-Error" class="definition panel" data-traverse-target="definition-Error">
             <h2 class="panel-title">
               <a name="/definitions/Error"></a>Error: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               
@@ -2898,8 +2894,7 @@
           <div id="definition-ValidationError" class="definition panel" data-traverse-target="definition-ValidationError">
             <h2 class="panel-title">
               <a name="/definitions/ValidationError"></a>ValidationError: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               
@@ -2945,8 +2940,7 @@
           <div id="definition-NotFoundError" class="definition panel" data-traverse-target="definition-NotFoundError">
             <h2 class="panel-title">
               <a name="/definitions/NotFoundError"></a>NotFoundError: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               
@@ -2992,8 +2986,7 @@
           <div id="definition-Cheese" class="definition panel" data-traverse-target="definition-Cheese">
             <h2 class="panel-title">
               <a name="/definitions/Cheese"></a>Cheese: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               
@@ -3103,8 +3096,7 @@
           <div id="definition-tag.yml--Tag" class="definition panel" data-traverse-target="definition-tag.yml--Tag">
             <h2 class="panel-title">
               <a name="/definitions/tag.yml#/Tag"></a>tag.yml#/Tag: object
-              <!-- <span class="json-property-type">
-              <span class="json-property-type">object</span>
+              <!-- <span class="json-property-type"><span class="json-property-type">object</span>
               <span class="json-property-range" title="Value limits"></span>
               
               


### PR DESCRIPTION
This commit fixes the following warning:
```bash
Running "sass:scss" (sass) task
WARNING: Note, that $header-sizes has been replaced with $header-styles. $header-sizes still works, but it is going to be depreciated.
         on line 77 of app/vendor/foundation/scss/typography/_base.scss, in function `build_from_header-sizes`
         from line 91 of app/vendor/foundation/scss/typography/_base.scss
         from line 10 of app/vendor/foundation/scss/typography/_typography.scss
         from line 31 of app/vendor/foundation/scss/foundation.scss
         from line 7 of app/stylesheets/spectacle.scss
```